### PR TITLE
Support buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ var collectKeysValues = function (object, stats) {
 /**
  * Main module's entry point
  * Calculates Bytes for the provided parameter
- * @param object - handles object/string/boolean
+ * @param object - handles object/string/boolean/buffer
  * @returns {*}
  */
 function sizeof(object) {
@@ -52,6 +52,8 @@ function sizeof(object) {
     bytes = ECMA_SIZES.BOOLEAN;
   } else if (_.isNumber(object)) {
     bytes = ECMA_SIZES.NUMBER;
+  } else if (Buffer.isBuffer(object)) {
+    bytes = object.length;
   }
   return bytes;
 }

--- a/index.js
+++ b/index.js
@@ -42,18 +42,21 @@ function sizeof(object) {
   var bytes = 0;
 
   if (_.isObject(object)) {
-    var stats = new Stats();
-    collectKeysValues(object, stats);
-    // calculate size in Bytes based on ECMAScript Language Specs
-    bytes = stats.calculateBytes();
+    if (Buffer.isBuffer(object)) {
+      bytes = object.length;
+    }
+    else {
+      var stats = new Stats();
+      collectKeysValues(object, stats);
+      // calculate size in Bytes based on ECMAScript Language Specs
+      bytes = stats.calculateBytes();
+    }
   } else if (_.isString(object)) {
     bytes = object.length * ECMA_SIZES.STRING;
   } else if (_.isBoolean(object)) {
     bytes = ECMA_SIZES.BOOLEAN;
   } else if (_.isNumber(object)) {
     bytes = ECMA_SIZES.NUMBER;
-  } else if (Buffer.isBuffer(object)) {
-    bytes = object.length;
   }
   return bytes;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,10 @@ describe('sizeof', function() {
   it('boolean size shall be 4', function() {
     sizeof(true).should.be.equal(4);
   });
+  
+  it('buffer size should be correct', function() {
+    sizeof(new Buffer(3)).should.be.equal(3);
+  });
 
   it('nested objects shall be counted in full', function() {
     // 4 one two-bytes char strings and 3 eighth-bytes numbers


### PR DESCRIPTION
object-sizeof can behave badly (go into a loop and make you use node-dump profiler) when given a buffer. This change should support buffers.